### PR TITLE
Post session

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Base Endpoint
 
-Base endpoint: [https://teammate-app.herokuapp.com/](https://teammate-app.herokuapp.com/)
+Base endpoint: [https://teammate-app.herokuapp.com](https://teammate-app.herokuapp.com)
 
 # Endpoints
 | Type | URL | Methods | Description |
@@ -9,7 +9,7 @@ Base endpoint: [https://teammate-app.herokuapp.com/](https://teammate-app.heroku
 | Authentication | /auth/token/login/ | POST | Login |
 | Authentication | /auth/token/logout/ | POST | Logout |
 | User Profile | /username | GET, POST, PATCH, DELETE |  |
-| Game Sessions | /session/ | GET, POST,  | List Game Sess |
+| Game Sessions | /session | GET, POST | List/Create Game |
 | Game Sessions | /session/pk | GET, PATCH, DELETE |  |
 | Game Sessions | /session/pk/competitor | POST |  |
 | Game Sessions | /session/pk/survey | GET, POST |  |
@@ -76,9 +76,9 @@ Response: No Data
 
 ---
 
-### List Game Session
+### List/Create Game Session
 
-> /session/
+> /session
 > 
 - Method: GET
 - Data json:
@@ -132,6 +132,42 @@ Response: No Data
     	}
     ]
     ```
-    
+
+- Method: GET
+- Body:
+    ```
+    {
+        "date": "2022-08-18",
+        "time": "16:15:00",
+        "session_type": "Competitive",
+        "match_type": "Doubles",
+        "location": 1
+    }
+    ```
+- Response: 201_Created
+    ```
+	{
+        "id": 13,
+        "host": "BillyBobJoe",
+        "host_info": {
+            "id": 9,
+            "username": "BillyBobJoe",
+            "first_name": "",
+            "last_name": ""
+        },
+        "date": "2022-08-18",
+        "time": "16:15:00",
+        "session_type": "Competitive",
+        "match_type": "Doubles",
+        "location": 1,
+        "location_info": {
+            "id": 1,
+            "park_name": "State Road Park",
+            "court_count": 2,
+            "court_surface": "Hard Court"
+        },
+        "guest": []
+    }
+    ```
 
 ..

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -39,9 +39,7 @@ class CourtSerializer(serializers.ModelSerializer):
 
 
 class GameSessionSerializer(serializers.ModelSerializer):
-    host = serializers.ReadOnlyField(source='user.username')
-    # host = serializers.SlugRelatedField(slug_field="username", read_only=True)
-    # guest = serializers.PrimaryKeyRelatedField(many=True, queryset=Guest.objects.all())
+    host = serializers.SlugRelatedField(slug_field="username", read_only=True)
     guest = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
     host_info = UserSerializer(source='host', read_only=True)
     location_info = CourtSerializer(source='location', read_only=True)

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -39,7 +39,10 @@ class CourtSerializer(serializers.ModelSerializer):
 
 
 class GameSessionSerializer(serializers.ModelSerializer):
-    guest = serializers.PrimaryKeyRelatedField(many=True, queryset=Guest.objects.all())
+    host = serializers.ReadOnlyField(source='user.username')
+    # host = serializers.SlugRelatedField(slug_field="username", read_only=True)
+    # guest = serializers.PrimaryKeyRelatedField(many=True, queryset=Guest.objects.all())
+    guest = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
     host_info = UserSerializer(source='host', read_only=True)
     location_info = CourtSerializer(source='location', read_only=True)
 

--- a/api/views.py
+++ b/api/views.py
@@ -1,11 +1,17 @@
 from django.shortcuts import render
-from rest_framework.generics import CreateAPIView, DestroyAPIView, ListAPIView, ListCreateAPIView, RetrieveUpdateDestroyAPIView
+from rest_framework.generics import (
+    CreateAPIView, 
+    DestroyAPIView, 
+    ListAPIView, 
+    ListCreateAPIView, 
+    RetrieveUpdateDestroyAPIView, 
+)
 from rest_framework.response import Response
 
 from .models import User, GameSession, Court, CourtAddress, UserAddress, Guest, Profile, AddressModelMixin
 
 from .serializers import GameSessionSerializer
-# Create your views here.
+
 
 def welcome(request):
     return Response({
@@ -13,7 +19,10 @@ def welcome(request):
         'description': 'Welcome to our app 👋'
     })
 
-class NewGameSession(ListCreateAPIView):
+
+class ListCreateGameSession(ListCreateAPIView):
     queryset = GameSession.objects.all()
     serializer_class = GameSessionSerializer
-    
+
+    def perform_create(self, serializer):
+        serializer.save(host=self.request.user)

--- a/api/views.py
+++ b/api/views.py
@@ -1,4 +1,5 @@
 from django.shortcuts import render
+from rest_framework import permissions
 from rest_framework.generics import (
     CreateAPIView, 
     DestroyAPIView, 
@@ -23,6 +24,7 @@ def welcome(request):
 class ListCreateGameSession(ListCreateAPIView):
     queryset = GameSession.objects.all()
     serializer_class = GameSessionSerializer
+    permission_class = [permissions.IsAuthenticated]
 
     def perform_create(self, serializer):
         serializer.save(host=self.request.user)

--- a/core/.env.sample
+++ b/core/.env.sample
@@ -1,0 +1,3 @@
+SECRET_KEY=he+iawdht@b^u_djj44b@&o4v+5&)e1(523_sm6y)!=7z@$bl$
+DEBUG=True
+DATABASE_URL=postgres://<username>:@127.0.0.1:5432/<dbname>

--- a/core/urls.py
+++ b/core/urls.py
@@ -22,5 +22,5 @@ urlpatterns = [
     path('auth/', include('rest_framework.urls')),
     path('auth/', include('djoser.urls')),
     path('auth/', include('djoser.urls.authtoken')),
-    path('session/', api_views.NewGameSession.as_view(), name='game-session-list'),
+    path('session', api_views.ListCreateGameSession.as_view(), name='game-session-list'),
 ]


### PR DESCRIPTION
Functionality to create new GameSession instances.

queryset=Guest.objects.all() was replaced with read_only=True, so that the guest field could remain empty when instantiating GameSession.

Document the HTTP body and response.

Significantly, the URL path was changed from '/sessions/' to '/sessions'. Frontend must be made aware upon merge.