### PR TITLE
removed .order_by function bc date/time don't exist on User object

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -134,7 +134,7 @@ class UserDetail(ListAPIView):
 
     def get_queryset(self):
         queryset = User.objects.filter(username=self.kwargs['username'])
-        return queryset.order_by("date","time")
+        return queryset
 
 # Returns confirmed games where user = host | guest
 class MyConfirmedGameSessions(ListAPIView):


### PR DESCRIPTION
Rachel was experiencing a bug because GET @ /<str:username> was attempting to return the queryset with order_by("date","time") and the User model does not include those fields (that is not true for the remaining 5 /<str:username> endpoints.

This PR just removes that function.

All endpoints were then tested locally.