### PR TITLE
Profile post rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,8 @@
-# Base Endpoint
+# Base URL
 
-Base endpoint: [https://teammate-app.herokuapp.com/](https://teammate-app.herokuapp.com/)
+[https://teammate-app.herokuapp.com/](https://teammate-app.herokuapp.com/)
 
 # Endpoints
-
-| Type | URL | Methods | Description |
-| --- | --- | --- | --- |
-| Authentication | /auth/users/ | POST | Create User |
-| Authentication | /auth/token/login/ | POST | Login |
-| Authentication | /auth/token/logout/ | POST | Logout |
-| User Profile | /profile/ | GET, POST, PATCH | List, Create, Patch Profile |
-| User Details | /<str:username> | GET | List User Details |
-| User’s Game Sessions | /<str:username>/confirmed/ | GET | Confirmed Games (user = host | guest) |
-| User’s Game Sessions | /<str:username>/confirmed-host/ | GET | Confirmed Games (user = host) |
-| User’s Game Sessions | /<str:username>/confirmed-guest/ | GET | Confirmed Games (user = guest) |
-| User’s Game Sessions | /<str:username>/open/ | GET | Open Games (user = host | guest) |
-| User’s Game Sessions | /<str:username>/open-host/ | GET | Open Games (user = host) |
-| User’s Game Sessions | /<str:username>/open-guest/ | GET | Open Games (user = guest) |
-| Game Sessions | /session/ | GET, POST,  | List All & Create Game Session |
-| Game Sessions | /session/?search | Filter Game Sessions |  |
-| Game Sessions | /session/<int:pk> | GET, PATCH, DELETE | Get, Update, Destroy Game Session |
-| Game Sessions | /session/<int:pk>/survey | GET, POST |  |
-| Game Sessions | /session/<int:pk>/guest/ | GET, POST | List, Create Guest for Game session |
-| Game Sessions | /session/<int:pk>/guest/<int:guest_pk>/ | GET, PATCH, DELETE | Change Guest Status, Delete Guest |
-| Court | /court/ | GET, POST | List &Create Court |
-| Court Address | /court/<int:pk>/address/ | GET, POST | List & Create Court Address |
 
 ## Authentication
 
@@ -157,17 +135,6 @@ Base endpoint: [https://teammate-app.herokuapp.com/](https://teammate-app.heroku
 - Data JSON:
     - As of 8/20/22, doubles games will return in both the confirmed or open endpoints so long as one guest’s status meets the criteria
 
-|  | user = host | user = guest | status = pending | status = accepted |
-| --- | --- | --- | --- | --- |
-| /<str:username> | X | X | X | X |
-| /<str:username>/confirmed/ | X | X |  | X |
-| /<str:username>/confirmed-host/ | X |  |  | X |
-| /<str:username>/confirmed-guest/ |  | X |  | X |
-| /<str:username>/open/ | X | X | X |  |
-| /<str:username>/open-host/ | X |  | X |  |
-| /<str:username>/open-guest/ |  | X | X |  |
-
-
 ## User Profiles
 
 ---
@@ -177,33 +144,10 @@ Base endpoint: [https://teammate-app.herokuapp.com/](https://teammate-app.heroku
 - Method: GET
 - Data JSON:
     - profile_pic: feature not yet built
-    - ntrp_rating: 2.5 - 7, increments of .5, defaults to 2.5 if request body is empty
+    - If user profile does not exist, one will be created
+    - ntrp_rating: 2.5 - 7, increments of .5, defaults to 2.5 (when creating)
     - A user can only have one profile
 - Response: Profile JSON Object, 200_OK :
-    
-    ```json
-    {
-    	"id": 27,
-    	"user": 5,
-    	"profile_pic": null,
-    	"ntrp_rating": "3.5"
-    }
-    ```
-    
-
-- Method: POST
-- Data JSON:
-    - profile_pic: feature not yet built
-    - ntrp_rating: 2.5 - 7, increments of .5, defaults to 2.5 if request body is empty
-    - A user can only have one profile
-    
-    ```json
-    {
-    	"ntrp_rating": 3.5
-    }
-    ```
-    
-- Response: Profile JSON Object, 201_CREATED :
     
     ```json
     {
@@ -218,6 +162,7 @@ Base endpoint: [https://teammate-app.herokuapp.com/](https://teammate-app.heroku
 - Method: PATCH
 - Data JSON:
     - profile_pic: feature not yet built
+    - If user profile does not exist, one will be created, as it first calls the get method
     - ntrp_rating: 2.5 - 7, increments of .5, defaults to 2.5 if request body is empty
     - A user can only have one profile
     
@@ -228,15 +173,6 @@ Base endpoint: [https://teammate-app.herokuapp.com/](https://teammate-app.heroku
     ```
     
 - Response: Profile JSON Object, 202_ACCEPTED:
-    
-    ```json
-    {
-    	"id": 27,
-    	"user": 5,
-    	"profile_pic": null,
-    	"ntrp_rating": "4"
-    }
-    ```
     
 
 ## Game Sessions

--- a/api/views.py
+++ b/api/views.py
@@ -104,10 +104,18 @@ class ListCreateCourtAddress(ListCreateAPIView):
 class ListCreateUpdateProfile(APIView):
     permission_classes = (IsOwnerOrReadOnly,)
 
+    # def get(self, request):
+    #     profile = request.user.profile
+    #     serializer = ProfileSerializer(profile)
+    #     return Response(serializer.data, status=status.HTTP_200_OK)
+    
     def get(self, request):
-        profile = request.user.profile
-        serializer = ProfileSerializer(profile)
-        return Response(serializer.data, status=status.HTTP_200_OK)
+        profile = Profile.objects.get(user_id=request.user)
+        if profile is not None:
+            serializer = ProfileSerializer(profile)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        else:
+            return Response(status=status.HTTP_404_NOT_FOUND)
 
     def post(self, request): 
         user = self.request.user

--- a/api/views.py
+++ b/api/views.py
@@ -117,6 +117,7 @@ class ListCreateUpdateProfile(APIView):
             return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     def patch (self, request, **kwargs):
+        self.get(request)
         profile = request.user.profile
         serializer = ProfileSerializer(profile, data=request.data, partial=True)
         if serializer.is_valid():


### PR DESCRIPTION
The creation of a user profile is now handled by the BE. If a GET request is made for a user profile, the get method try to check that one exists, if it does, it will return it; if it does not exist, it will create one (with the "except" code).

The get method is also called at the start of the patch method, preventing a 500 error being thrown should a user somehow stumble upon patching their profile before it even exists.

This code has been tested locally, and the changes are documented in the README.