### PR TITLE
migration for refactor of guest validator function

### DIFF
--- a/api/migrations/0018_alter_guest_game_session.py
+++ b/api/migrations/0018_alter_guest_game_session.py
@@ -15,6 +15,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='guest',
             name='game_session',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='guest', to='api.gamesession', validators=[api.models.restrict_amount]),
+            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='guest', to='api.gamesession', validators=[api.models.restrict_guest_amount_on_game_session]),
         ),
     ]


### PR DESCRIPTION
Migration #18, renamed the validator function name as it was throwing errors.